### PR TITLE
feat: update to use new USRBG api

### DIFF
--- a/USRBG.plugin.js
+++ b/USRBG.plugin.js
@@ -12,7 +12,6 @@
  */
 const USRBG_ORIGINAL_PREMIUM_TYPE = Symbol('USRBG_ORIGINAL_PREMIUM_TYPE');
 const USRBG_ORIGINAL_BANNER = Symbol('USRBG_ORIGINAL_BANNER');
-const cachebust = Date.now();
 module.exports = class USRBG {
     constructor(meta) {
         this.meta = meta;
@@ -105,7 +104,7 @@ module.exports = class USRBG {
 
     getImageUrl(database, userId) {
         const { endpoint, bucket, prefix } = database;
-        return `${endpoint}/${bucket}/${prefix}${userId}?${cachebust}`;
+        return `${endpoint}/${bucket}/${prefix}${userId}?${database.users.get(userId)}`;
     }
 
     async getDatabase() {
@@ -114,7 +113,7 @@ module.exports = class USRBG {
         );
         return {
             ...json,
-            users: new Set(json.users)
+            users: new Map(Object.entries(json.users))
         }
     }
 


### PR DESCRIPTION
USRBG has moved storage to a new dedicated platform, allowing better integration and more control over the data that can be made available for plugins to use. This has allowed creation of a new API that has several benefits:

- The API's data is updated immediately upon a user's background being approved
- Data sent over-the-pipe can be reduced, only sending a list of user ids and a small bit of metadata (~800kB instead of the current 2.7MB)
- Dead links are no longer a possibility and do not need to be filtered out of the dataset